### PR TITLE
Match sign and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Input parameters:
 - `temp`: global temperature series
 - `gtap_spec`: A `String` specifying which GTAP temperature-welfare results dataframe from Moore et al to use for the damage function. Must be one of `"AgMIP_AllDF"`, `"AgMIP_NoNDF"`, `"highDF"`, `"lowDF"`, or `"midDF"`. See documentation for a description of these choices.
 - `gtap_df_all`: Holds temperature-welfare data for all five `gtap_spec` choices. Only the one specified by `gtap_spec` will be used when the component is run
-- `floor_on_damages`: A `Bool` specifying whether or not to limit damages (negative values of the `agcost` variable) to 100% of the size of the agricultural sector. Default value is `true`.
-- `ceiling_on_benefits`: A `Bool` specifying whether or not to limit benefits (positive values of the `agcost` variable) to 100% of the size of the agricultural sector. Default value is `false`.
+- `floor_on_damages`: A `Bool` specifying whether or not to limit damages to 100% of the size of the agricultural sector. Default value is `true`.
+- `ceiling_on_benefits`: A `Bool` specifying whether or not to limit benefits to 100% of the size of the agricultural sector. Default value is `false`.
 - `agrish0`: Initial agricultural share of GDP
 - `agel`: elasticity
 - `gdp90`
 - `pop90`
 
 Calculated variables:
-- `AgLossGTAP`: Percent impact on the agricultural sector in each year
-- `agcost`: Total impact on the agricultural sector in each year. (A negative value means damages, positive values mean benefits.)
+- `AgLossGTAP`: Percent loss on the agricultural sector in each year
+- `agcost`: Total cost on the agricultural sector in each year.
 - `gtap_df`: The selected temperature-welfare data used for the damage function, specified by the `gtap_spec` parameter, selected from all the data held in `gtap_df_all`
 
 ## Docstrings of available functions
@@ -69,11 +69,9 @@ Population and income levels are set to values from the USG2 MERGE Optimistic sc
 Temperature is set to output from the DICE model. If the user specifies `pulse=true`, then 
 temperature is set to output from the DICE model with a 1 GtC pulse of CO2 emissions in 2020.
 
-If `floor_on_damages` = true, then the agricultural damages (negative values of the 
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
+If `floor_on_damages` = true, then the agricultural damages in each timestep will not be allowed to exceed 100% of the size of the 
 agricultural sector in each region.
-If `ceiling_on_benefits` = true, then the agricultural benefits (positive values of the
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
+If `ceiling_on_benefits` = true, then the agricultural benefits in each timestep will not be allowed to exceed 100% of the size of the 
 agricultural sector in each region.
 
 **MooreAg.get_ag_scc**
@@ -89,9 +87,7 @@ pure rate of time preference discounting with the specified keyword argument `pr
 Optional keyword argument `horizon` can specify the final year of marginal damages to be 
 included in the SCC calculation, with a default year of 2300.
 
-If `floor_on_damages` = true, then the agricultural damages (negative values of the 
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
+If `floor_on_damages` = true, then the agricultural damages in each timestep will not be allowed to exceed 100% of the size of the 
 agricultural sector in each region.
-If `ceiling_on_benefits` = true, then the agricultural benefits (positive values of the
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
+If `ceiling_on_benefits` = true, then the agricultural benefits in each timestep will not be allowed to exceed 100% of the size of the 
 agricultural sector in each region.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ The `MooreAg` package defines an `Agriculture` component to be used in Integrate
 
 ## The Agriculture Component
 
-The `Agriculture` component is a Mimi component implementing Moore et al's agricultural damage function. The component is defined in "src/AgricultureComponent.jl". It has a variable called `gtap_df` which is a 16 x 3 Array of percent welfare impact data (16 FUND regions x 3 temperature points). In the run_timestep function, this component takes temperature for that timestep and uses the gtap dataframe to linearly interpolate or extrapolate to get the percent impact for that timestep, saved in variable `AgLossGTAP`. 
+The `Agriculture` component is a Mimi component implementing Moore et al's agricultural damage function. The component is defined in "src/AgricultureComponent.jl". It has a variable called `gtap_df` which is a 16 x 3 Array of percent welfare impact data (16 FUND regions x 3 temperature points). In the run_timestep function, this component takes temperature for that timestep and uses the gtap dataframe to linearly interpolate or extrapolate to get the percent loss for that timestep, saved in variable `AgLossGTAP`. 
 
 There are 5 choices of temperature-welfare dataframes that can be used to form the basis of the damage function. They are:
 - "midDF" - the median result from Moore et al's meta analysis of yield responses

--- a/src/core/AgricultureComponent.jl
+++ b/src/core/AgricultureComponent.jl
@@ -44,13 +44,13 @@ using Mimi
             v.agrish[t, r] = p.agrish0[r] * (ypc / ypc90)^(-p.agel)
 
             # Interpolate for p.temp, using the three gtap welfare points with the additional origin (0,0) point
-            loss = linear_interpolate([0, v.gtap_df[r, :]...], collect(0:3), p.temp[t])
-            loss = p.floor_on_damages ? max(-100, loss) : loss
-            loss = p.ceiling_on_benefits ? min(100, loss)  : loss
-            v.AgLossGTAP[t, r] = loss / 100
+            impact = linear_interpolate([0, v.gtap_df[r, :]...], collect(0:3), p.temp[t])
+            impact = p.floor_on_damages ? max(-100, impact) : impact
+            impact = p.ceiling_on_benefits ? min(100, impact)  : impact
+            v.AgLossGTAP[t, r] = - impact / 100 # We take the negative to go from impact to loss
 
             # Calculate total cost for the ag sector based on the percent loss
-            v.agcost[t, r] = p.income[t, r] * v.agrish[t, r] * v.AgLossGTAP[t, r]  # take out the -1 from original fund component here because damages are the other sign in Moore data
+            v.agcost[t, r] = p.income[t, r] * v.agrish[t, r] * v.AgLossGTAP[t, r]
         end
     end
 end

--- a/src/core/get_ag_scc.jl
+++ b/src/core/get_ag_scc.jl
@@ -12,12 +12,10 @@ pure rate of time preference discounting with the specified keyword argument `pr
 Optional keyword argument `horizon` can specify the final year of marginal damages to be 
 included in the SCC calculation, with a default year of 2300.
 
-If `floor_on_damages` = true, then the agricultural damages (negative values of the 
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
-agricultural sector in each region.
-If `ceiling_on_benefits` = true, then the agricultural benefits (positive values of the
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
-agricultural sector in each region.
+If `floor_on_damages` = true, then the agricultural damages in each timestep will not be
+allowed to exceed 100% of the size of the agricultural sector in each region.
+If `ceiling_on_benefits` = true, then the agricultural benefits in each timestep will not
+be allowed to exceed 100% of the size of the agricultural sector in each region.
 """
 function get_ag_scc(gtap::String; 
     prtp::Float64 = 0.03, 
@@ -38,7 +36,7 @@ function get_ag_scc(gtap::String;
     # calculate SCC 
     base_damages = dropdims(sum(base_m[:Agriculture, :agcost], dims=2), dims=2)
     pulse_damages = dropdims(sum(pulse_m[:Agriculture, :agcost], dims=2), dims=2)
-    marginal_damages = -1 * (pulse_damages - base_damages) * 10^9 / 10^9 * 12/44  # 10^9 for billions of dollars; /10^9 for Gt pulse; 12/44 to go from $/ton C to $/ton CO2
+    marginal_damages = (pulse_damages - base_damages) * 10^9 / 10^9 * 12/44  # 10^9 for billions of dollars; /10^9 for Gt pulse; 12/44 to go from $/ton C to $/ton CO2
 
     start_idx = findfirst(isequal(pulse_year), years)
     end_idx = findfirst(isequal(horizon), years)

--- a/src/core/get_model.jl
+++ b/src/core/get_model.jl
@@ -17,12 +17,10 @@ Population and income levels are set to values from the USG2 MERGE Optimistic sc
 Temperature is set to output from the DICE model. If the user specifies `pulse=true`, then 
 temperature is set to output from the DICE model with a 1 GtC pulse of CO2 emissions in 2020.
 
-If `floor_on_damages` = true, then the agricultural damages (negative values of the 
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
-agricultural sector in each region.
-If `ceiling_on_benefits` = true, then the agricultural benefits (positive values of the
-`agcost` variable) in each timestep will not be allowed to exceed 100% of the size of the 
-agricultural sector in each region.
+If `floor_on_damages` = true, then the agricultural damages in each timestep will not be allowed
+to exceed 100% of the size of the agricultural sector in each region.
+If `ceiling_on_benefits` = true, then the agricultural benefits in each timestep will not be
+allowed to exceed 100% of the size of the agricultural sector in each region.
 """
 function get_model( gtap::String; 
                     pulse::Bool=false,

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -10,7 +10,7 @@ end
 # test invalid GTAP spec:
 @test_throws ErrorException m = MooreAg.get_model("foo")
 m = MooreAg.get_model("midDF")
-update_param!(m, :gtap_spec, "foo")
+update_param!(m, :Agriculture, :gtap_spec, "foo")
 @test_throws ErrorException run(m)  # should error with helpful message
 
 # Test the floor on damages

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -4,7 +4,7 @@
 
 results = readdlm(joinpath(@__DIR__, "../data/validation/ag_scc.csv"), ',')
 mimi_sccs = Vector{Any}()
-i = 2
+global i = 2
 for gtap in MooreAg.gtaps 
     for dr in [0.025, 0.03, 0.05]
         println(gtap, dr)


### PR DESCRIPTION
One pretty confusing thing in this repo is that things are named `cost` and `loss`, but then the interpretation is that a positive number is something good, and a negative number is something bad, i.e. things are just the other way from what one would expect from the name.

Really with the current signs on things, everything should be named `impact`, then the sign and name would match.

This PR goes the other way: I flip the sign for the `loss` and `cost` variable, so that now for `agcost`, a positive number is a harm/damage. That is in-line with the way we're handling all the other damage functions now, and will hopefully reduce confusion down the road.

This is a breaking change, so downstream users have to be careful :)

@fmoore and @ckingdon95, if you want to take a quick look whether this all makes sense to you, that would be great.