### PR TITLE
Add warning for AgMIP probabilty distributions and return nothing

### DIFF
--- a/src/core/AgricultureComponent.jl
+++ b/src/core/AgricultureComponent.jl
@@ -24,6 +24,7 @@ using Mimi
     AgLossGTAP = Variable(index=[time,fund_regions]) # Moore's fractional loss (intermediate variable for calculating agcost)
 
     gtap_df = Parameter(index=[fund_regions, 3])  # three temperature data points per region
+    gtap_name = Parameter{String}() # the name of the gtap damage function
 
     floor_on_damages = Parameter{Bool}(default = true)
     ceiling_on_benefits = Parameter{Bool}(default = false)

--- a/src/core/get_model.jl
+++ b/src/core/get_model.jl
@@ -60,6 +60,7 @@ function get_model( gtap::String;
     gtap_df = gtap_df_all[:, :, gtap_idx]
 
     update_param!(m, :Agriculture, :gtap_df, gtap_df)
+    update_param!(m, :Agriculture, :gtap_name, gtap)
     update_param!(m, :Agriculture, :floor_on_damages, floor_on_damages)
     update_param!(m, :Agriculture, :ceiling_on_benefits, ceiling_on_benefits)
 

--- a/src/core/mcs.jl
+++ b/src/core/mcs.jl
@@ -1,18 +1,23 @@
-function get_probdists_gtap_df(n=1000)
-    highDF = gtap_df_all[:, :, 3]
-    lowDF = gtap_df_all[:, :, 4]
-    midDF = gtap_df_all[:, :, 5]
+function get_probdists_gtap_df(gtap, n=1000)
+    if gtap in ["highDF", "midDF", "lowDF"]
+        highDF = gtap_df_all[:, :, 3]
+        lowDF = gtap_df_all[:, :, 4]
+        midDF = gtap_df_all[:, :, 5]
 
-    # For each region and temperature point we construct an interpolation where the x values are between 0 and 1
-    # and the y values are the values from the three scenarios.
-    dists = [LinearInterpolation([0.,0.5,1.], [lowDF[r,temp],midDF[r,temp], highDF[r,temp]]) for r in 1:16, temp in 1:3]
+        # For each region and temperature point we construct an interpolation where the x values are between 0 and 1
+        # and the y values are the values from the three scenarios.
+        dists = [LinearInterpolation([0.,0.5,1.], [lowDF[r,temp],midDF[r,temp], highDF[r,temp]]) for r in 1:16, temp in 1:3]
 
-    # We only sample one set of random numbers, as we want perfect correlation between all the individual
-    # parameter values.
-    samples = rand(TriangularDist(0., 1., 0.5), n)
+        # We only sample one set of random numbers, as we want perfect correlation between all the individual
+        # parameter values.
+        samples = rand(TriangularDist(0., 1., 0.5), n)
 
-    # Now evaluate the interpolated function we created above with the samples from the triangular distributions
-    sample_stores = [Mimi.SampleStore(dists[r,temp].(samples)) for r in 1:16, temp in 1:3]
+        # Now evaluate the interpolated function we created above with the samples from the triangular distributions
+        sample_stores = [Mimi.SampleStore(dists[r,temp].(samples)) for r in 1:16, temp in 1:3]
 
-    return sample_stores
+        return sample_stores
+    else
+        @warn "No probability distributions available for gtap damage function entered ($gtap), returning `nothing`."
+        return nothing
+    end
 end


### PR DESCRIPTION
Issue: The `get_probdists_gtap_df` function does not take the damage function as an argument, so it returns samples from a probability distributionconstructed from a distribution of `lowDF`, `midDF`, and `highDF` for all damage function settings.

Update: The function will now return those samples only if the  damage function is one of `lowDF`, `midDF`, and `highDF`, and otherwise return `nothing` since we do not currently have a method to produce distributions for that damage function. In addition, this PR adds the parameter `gtap_name` to the component so that any model using the component can easily recover the name of the damage function used to specific the component. 

@djsmithumn and @bryanparthum for awareness
